### PR TITLE
tw-29431765 | Create base image styles for all aspect ratios

### DIFF
--- a/config/core.entity_view_display.paragraph.sa_card.default.yml
+++ b/config/core.entity_view_display.paragraph.sa_card.default.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.field.paragraph.sa_card.sa_card_image
     - field.field.paragraph.sa_card.sa_description
     - field.field.paragraph.sa_card.sa_header
+    - field.field.paragraph.sa_card.sa_link
     - paragraphs.paragraphs_type.sa_card
   module:
     - ds
@@ -29,6 +30,8 @@ third_party_settings:
             image_col_classes_token: ''
             content_col_classes: col-md-8
             content_col_classes_token: ''
+            height: 0
+            height_token: ''
     regions:
       image:
         - sa_card_image
@@ -47,7 +50,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: sa_5_4
+      view_mode: wide_5_4
       link: false
     third_party_settings:
       nomarkup:
@@ -70,7 +73,7 @@ content:
       nomarkup:
         enabled: false
         separator: '|'
-        referenced_entity: false
+        referenced_entity: ''
       ds:
         ds_limit: ''
         ft:

--- a/config/core.entity_view_display.paragraph.sa_carousel_item.default.yml
+++ b/config/core.entity_view_display.paragraph.sa_carousel_item.default.yml
@@ -40,7 +40,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: 'sa_5_4'
+      view_mode: wide_5_4
       link: false
     third_party_settings:
       nomarkup:

--- a/config/core.entity_view_display.paragraph.sa_media.default.yml
+++ b/config/core.entity_view_display.paragraph.sa_media.default.yml
@@ -52,7 +52,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: default
+      view_mode: easy_reponsive_images
       link: false
     third_party_settings:
       nomarkup:

--- a/config/core.entity_view_display.paragraph.sa_side_by_side.default.yml
+++ b/config/core.entity_view_display.paragraph.sa_side_by_side.default.yml
@@ -61,7 +61,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: sa_5_4
+      view_mode: wide_5_4
       link: false
     third_party_settings:
       nomarkup:


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [Create base image styles for all aspect ratios](https://kanopi.teamwork.com/app/tasks/29431765)

Update all image displays to use the new easy responsive image display modes. #31
https://github.com/kanopi/saplings-content-types/issues/12
https://github.com/kanopi/saplings-component-types/issues/31

So we use media image display modes in the two content types and a few components. We need to update those config files, make releases for all 3 repos and then test

## Acceptance Criteria
* All components that use an image have been updated to use the new Easy Responsive Image styles

## Deploy Notes
_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc. This should also include work that needs to be 
accomplished post-launch like enabling a plugin._
