### PR TITLE
Updates order of styles fields to be the same and installs paragraphs edit module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "drupal/entity_reference_revisions": "*",
         "drupal/nomarkup": "^1.0",
         "drupal/paragraphs": "*",
+        "drupal/paragraphs_edit": "*",
         "drupal/ui_patterns_field_formatters": "*",
         "drupal/ui_patterns_field_group": "*",
         "drupal/viewsreference": "^2.0@beta",

--- a/config/core.entity_form_display.paragraph.sa_accordion.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_accordion.default.yml
@@ -19,11 +19,7 @@ third_party_settings:
   field_group:
     group_styles:
       children:
-        - sa_margin
-        - sa_padding
-        - sa_container
-        - sa_background
-        - sa_width
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
@@ -34,6 +30,69 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_spacing
+        - group_background
+        - group_width
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_spacing:
+      children:
+        - sa_margin
+        - sa_padding
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 6
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_container
+        - sa_width
+      label: Width
+      region: hidden
+      parent_name: group_layout
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_accordion.default

--- a/config/core.entity_form_display.paragraph.sa_block.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_block.default.yml
@@ -19,11 +19,7 @@ third_party_settings:
   field_group:
     group_styles:
       children:
-        - sa_background
-        - sa_width
-        - sa_margin
-        - sa_padding
-        - sa_container
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
@@ -34,6 +30,69 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_spacing
+        - group_background
+        - group_width
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_spacing:
+      children:
+        - sa_margin
+        - sa_padding
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 6
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_container
+        - sa_width
+      label: Width
+      region: hidden
+      parent_name: group_layout
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_block.default

--- a/config/core.entity_form_display.paragraph.sa_carousel.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_carousel.default.yml
@@ -19,11 +19,7 @@ third_party_settings:
   field_group:
     group_styles:
       children:
-        - sa_background
-        - sa_width
-        - sa_margin
-        - sa_padding
-        - sa_container
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
@@ -34,6 +30,69 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_spacing
+        - group_background
+        - group_width
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_spacing:
+      children:
+        - sa_margin
+        - sa_padding
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 6
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_container
+        - sa_width
+      label: Width
+      region: hidden
+      parent_name: group_layout
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_carousel.default

--- a/config/core.entity_form_display.paragraph.sa_columns.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_columns.default.yml
@@ -25,27 +25,118 @@ third_party_settings:
   field_group:
     group_styles:
       children:
-        - sa_column_gutters
-        - sa_columns_desktop
-        - sa_columns_tablet
-        - sa_columns_mobile
-        - sa_align_items_vertically
-        - sa_justify_content_horizontal
-        - sa_background
-        - sa_width
-        - sa_margin
-        - sa_padding
-        - sa_container
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
-      weight: 4
+      weight: 3
       format_type: details
+      format_settings:
+        classes: row
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_columns
+        - group_width
+        - group_spacing
+        - group_background
+        - group_align
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 7
+      format_type: tabs
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        open: false
+        direction: horizontal
+        width_breakpoint: 640
+    group_align:
+      children:
+        - sa_align_items_vertically
+        - sa_justify_content_horizontal
+      label: Alignment
+      region: content
+      parent_name: group_layout
+      weight: 26
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+        direction: horizontal
+        width_breakpoint: 640
+    group_columns:
+      children:
+        - sa_column_gutters
+        - sa_columns_desktop
+        - sa_columns_tablet
+        - sa_columns_mobile
+      label: Columns
+      region: content
+      parent_name: group_layout
+      weight: 13
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_spacing:
+      children:
+        - sa_padding
+        - sa_margin
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 24
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_width
+        - sa_container
+      label: Width
+      region: content
+      parent_name: group_layout
+      weight: 23
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 25
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_columns.default

--- a/config/core.entity_form_display.paragraph.sa_faq.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_faq.default.yml
@@ -19,21 +19,80 @@ third_party_settings:
   field_group:
     group_styles:
       children:
-        - sa_margin
-        - sa_padding
-        - sa_container
-        - sa_background
-        - sa_width
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
       weight: 3
       format_type: details
       format_settings:
-        classes: ''
+        classes: row
         show_empty_fields: false
         id: ''
         open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_spacing
+        - group_background
+        - group_width
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_spacing:
+      children:
+        - sa_margin
+        - sa_padding
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 6
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_container
+        - sa_width
+      label: Width
+      region: hidden
+      parent_name: group_layout
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_faq.default

--- a/config/core.entity_form_display.paragraph.sa_filtered_list.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_filtered_list.default.yml
@@ -19,11 +19,7 @@ third_party_settings:
   field_group:
     group_styles:
       children:
-        - sa_background
-        - sa_width
-        - sa_margin
-        - sa_padding
-        - sa_container
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
@@ -34,6 +30,69 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_spacing
+        - group_background
+        - group_width
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_spacing:
+      children:
+        - sa_margin
+        - sa_padding
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 6
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_container
+        - sa_width
+      label: Width
+      region: hidden
+      parent_name: group_layout
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_filtered_list.default

--- a/config/core.entity_form_display.paragraph.sa_media.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_media.default.yml
@@ -20,11 +20,7 @@ third_party_settings:
   field_group:
     group_styles:
       children:
-        - sa_background
-        - sa_width
-        - sa_margin
-        - sa_padding
-        - sa_container
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
@@ -33,8 +29,71 @@ third_party_settings:
       format_settings:
         classes: row
         show_empty_fields: false
-        id: styles
+        id: ''
         open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_spacing
+        - group_background
+        - group_width
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_spacing:
+      children:
+        - sa_margin
+        - sa_padding
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 6
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_container
+        - sa_width
+      label: Width
+      region: hidden
+      parent_name: group_layout
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_media.default

--- a/config/core.entity_form_display.paragraph.sa_side_by_side.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_side_by_side.default.yml
@@ -19,9 +19,9 @@ dependencies:
     - text
 third_party_settings:
   field_group:
-    sa_reverse_order
     group_styles:
       children:
+        - sa_reverse_order
         - group_layout
       label: Styles
       region: content

--- a/config/core.entity_form_display.paragraph.sa_side_by_side.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_side_by_side.default.yml
@@ -19,24 +19,83 @@ dependencies:
     - text
 third_party_settings:
   field_group:
+    sa_reverse_order
     group_styles:
       children:
-        - sa_reverse_order
-        - sa_margin
-        - sa_padding
-        - sa_width
-        - sa_container
-        - sa_background
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
       weight: 3
       format_type: details
       format_settings:
-        classes: ''
+        classes: row
         show_empty_fields: false
         id: ''
         open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_spacing
+        - group_background
+        - group_width
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_spacing:
+      children:
+        - sa_margin
+        - sa_padding
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 6
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_container
+        - sa_width
+      label: Width
+      region: hidden
+      parent_name: group_layout
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_side_by_side.default

--- a/config/core.entity_form_display.paragraph.sa_tabs.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_tabs.default.yml
@@ -19,11 +19,7 @@ third_party_settings:
   field_group:
     group_styles:
       children:
-        - sa_background
-        - sa_width
-        - sa_margin
-        - sa_padding
-        - sa_container
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
@@ -34,6 +30,69 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_spacing
+        - group_background
+        - group_width
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_spacing:
+      children:
+        - sa_margin
+        - sa_padding
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 6
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_container
+        - sa_width
+      label: Width
+      region: hidden
+      parent_name: group_layout
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_tabs.default

--- a/config/core.entity_form_display.paragraph.sa_text.default.yml
+++ b/config/core.entity_form_display.paragraph.sa_text.default.yml
@@ -17,11 +17,7 @@ third_party_settings:
   field_group:
     group_styles:
       children:
-        - sa_background
-        - sa_width
-        - sa_margin
-        - sa_padding
-        - sa_container
+        - group_layout
       label: Styles
       region: content
       parent_name: ''
@@ -32,6 +28,69 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: false
+        description: ''
+        required_fields: true
+    group_layout:
+      children:
+        - group_spacing
+        - group_background
+        - group_width
+      label: Layout
+      region: content
+      parent_name: group_styles
+      weight: 20
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        direction: horizontal
+        width_breakpoint: 640
+    group_spacing:
+      children:
+        - sa_margin
+        - sa_padding
+      label: Spacing
+      region: content
+      parent_name: group_layout
+      weight: 6
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_width:
+      children:
+        - sa_container
+        - sa_width
+      label: Width
+      region: hidden
+      parent_name: group_layout
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_background:
+      children:
+        - sa_background
+      label: Background
+      region: content
+      parent_name: group_layout
+      weight: 7
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
         description: ''
         required_fields: true
 id: paragraph.sa_text.default

--- a/config/field.field.paragraph.sa_accordion.sa_container.yml
+++ b/config/field.field.paragraph.sa_accordion.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_accordion
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_accordion.sa_width.yml
+++ b/config/field.field.paragraph.sa_accordion.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_accordion
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.paragraph.sa_block.sa_container.yml
+++ b/config/field.field.paragraph.sa_block.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_block
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_block.sa_width.yml
+++ b/config/field.field.paragraph.sa_block.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_block
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.paragraph.sa_carousel.sa_container.yml
+++ b/config/field.field.paragraph.sa_carousel.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_carousel
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_carousel.sa_width.yml
+++ b/config/field.field.paragraph.sa_carousel.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_carousel
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.paragraph.sa_columns.sa_container.yml
+++ b/config/field.field.paragraph.sa_columns.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_columns
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_columns.sa_width.yml
+++ b/config/field.field.paragraph.sa_columns.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_columns
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.paragraph.sa_faq.sa_container.yml
+++ b/config/field.field.paragraph.sa_faq.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_faq
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_faq.sa_width.yml
+++ b/config/field.field.paragraph.sa_faq.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_faq
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.paragraph.sa_filtered_list.sa_container.yml
+++ b/config/field.field.paragraph.sa_filtered_list.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_filtered_list
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_filtered_list.sa_width.yml
+++ b/config/field.field.paragraph.sa_filtered_list.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_filtered_list
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.paragraph.sa_media.sa_container.yml
+++ b/config/field.field.paragraph.sa_media.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_media
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_media.sa_width.yml
+++ b/config/field.field.paragraph.sa_media.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_media
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.paragraph.sa_side_by_side.sa_container.yml
+++ b/config/field.field.paragraph.sa_side_by_side.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_side_by_side
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_side_by_side.sa_width.yml
+++ b/config/field.field.paragraph.sa_side_by_side.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_side_by_side
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.paragraph.sa_tabs.sa_container.yml
+++ b/config/field.field.paragraph.sa_tabs.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_tabs
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_tabs.sa_width.yml
+++ b/config/field.field.paragraph.sa_tabs.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_tabs
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.paragraph.sa_text.sa_container.yml
+++ b/config/field.field.paragraph.sa_text.sa_container.yml
@@ -11,7 +11,7 @@ field_name: sa_container
 entity_type: paragraph
 bundle: sa_text
 label: Container
-description: ''
+description: 'The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element. Choosing full width will allow the container to take up the fill width of the screen, and if a background color is chosen, it will stretch across the entire screen from start to end.'
 required: false
 translatable: false
 default_value:

--- a/config/field.field.paragraph.sa_text.sa_width.yml
+++ b/config/field.field.paragraph.sa_text.sa_width.yml
@@ -11,7 +11,7 @@ field_name: sa_width
 entity_type: paragraph
 bundle: sa_text
 label: Width
-description: ''
+description: 'The width setting controls the width of the element, but not the width of the container. The container width will determine how far the background color stretches across the screen and will control the total width of the container that holds the element.'
 required: false
 translatable: false
 default_value: {  }

--- a/recipe.yml
+++ b/recipe.yml
@@ -20,5 +20,6 @@ install:
   - field_group
   - nomarkup
   - paragraphs
+  - paragraphs_edit
   - ui_patterns_field_formatters
   - viewsreference


### PR DESCRIPTION
When Editing the Paragraphs;
The order of the fields is inconsistent across the different paragraphs.
I think the Width and Container nomenclature could use some clarity - Not super clear how they differ and what does what.

Also Installs the Paragraphs Edit module.

## Acceptance Criteria
* Adds description to Container and Width Fields
* Sets universal display for style fields
* Installs the paragraphs edit module

## Related Tickets
https://kanopi.teamwork.com/app/tasks/29490887
https://kanopi.teamwork.com/app/tasks/29489573

## Deploy Notes
https://github.com/kanopi/saplings-component-types/pull/38
