### PR TITLE
converts block to use SDC display

### DIFF
--- a/config/core.entity_view_display.paragraph.sa_block.default.yml
+++ b/config/core.entity_view_display.paragraph.sa_block.default.yml
@@ -16,12 +16,92 @@ dependencies:
     - block_field
     - element_class_formatter
     - nomarkup
+    - options
+    - sdc_display
     - text
+third_party_settings:
+  sdc_display:
+    enabled: true
+    component:
+      machine_name: 'arbor:container'
+      show_deprecated: null
+    mappings:
+      static:
+        props:
+          container: null
+          margin: null
+          padding: null
+          background: null
+          width: null
+          variant: null
+        slots:
+          header:
+            value: ''
+            format: full_html
+          description:
+            value: ''
+            format: full_html
+          content:
+            value: ''
+            format: full_html
+      dynamic:
+        props:
+          attributes: ''
+          container: sa_container
+          margin: sa_margin
+          padding: sa_padding
+          background: sa_background
+          width: sa_width
+          variant: null
+        slots:
+          header:
+            sa_header: sa_header
+            sa_background: null
+            sa_block: null
+            sa_container: null
+            sa_description: null
+            sa_margin: null
+            sa_padding: null
+            sa_width: null
+          description:
+            sa_description: sa_description
+            sa_background: null
+            sa_block: null
+            sa_container: null
+            sa_header: null
+            sa_margin: null
+            sa_padding: null
+            sa_width: null
+          content:
+            sa_block: sa_block
+            sa_background: null
+            sa_container: null
+            sa_description: null
+            sa_header: null
+            sa_margin: null
+            sa_padding: null
+            sa_width: null
 id: paragraph.sa_block.default
 targetEntityType: paragraph
 bundle: sa_block
 mode: default
 content:
+  sa_background:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings:
+      nomarkup:
+        enabled: true
+        separator: '|'
+        referenced_entity: ''
+      sdc_display:
+        enabled: 0
+        component:
+          machine_name: null
+          show_deprecated: 0
+    weight: 3
+    region: content
   sa_block:
     type: block_field
     label: hidden
@@ -32,6 +112,22 @@ content:
         separator: '|'
         referenced_entity: ''
     weight: 2
+    region: content
+  sa_container:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings:
+      nomarkup:
+        enabled: true
+        separator: '|'
+        referenced_entity: ''
+      sdc_display:
+        enabled: 0
+        component:
+          machine_name: null
+          show_deprecated: 0
+    weight: 4
     region: content
   sa_description:
     type: text_default
@@ -61,10 +157,53 @@ content:
         referenced_entity: ''
     weight: 0
     region: content
+  sa_margin:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings:
+      nomarkup:
+        enabled: true
+        separator: '|'
+        referenced_entity: ''
+      sdc_display:
+        enabled: 0
+        component:
+          machine_name: null
+          show_deprecated: 0
+    weight: 7
+    region: content
+  sa_padding:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings:
+      nomarkup:
+        enabled: true
+        separator: '|'
+        referenced_entity: ''
+      sdc_display:
+        enabled: 0
+        component:
+          machine_name: null
+          show_deprecated: 0
+    weight: 5
+    region: content
+  sa_width:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings:
+      nomarkup:
+        enabled: true
+        separator: '|'
+        referenced_entity: ''
+      sdc_display:
+        enabled: 0
+        component:
+          machine_name: null
+          show_deprecated: 0
+    weight: 6
+    region: content
 hidden:
-  sa_background: true
-  sa_container: true
   sa_label: true
-  sa_margin: true
-  sa_padding: true
-  sa_width: true


### PR DESCRIPTION
## Description
Teamwork Ticket(s): https://kanopi.teamwork.com/app/tasks/29771174

Converts Block  to an SDC component based on the new Arbor theme.

## Deploy Notes
https://github.com/kanopi/saplings-component-types/pull/67
